### PR TITLE
fix loading data for choose_location

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -14,9 +14,8 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
 
-    var arguments3 = ModalRoute.of(context)!.settings.arguments;
-
-    var data = arguments3!=null? arguments3 as  Map<String, dynamic>:{};
+    data = data.isNotEmpty ? data = data :
+      data = ModalRoute.of(context)!.settings.arguments as Map;
 
     // data = (data.isNotEmpty ?? true) ? ModalRoute.of(context)!.settings.arguments as Map : data;
     print(data);


### PR DESCRIPTION
variable `data` already declared, so you can use it as `Map`
```dart
    var arguments3 = ModalRoute.of(context)!.settings.arguments;

    var data = arguments3!=null? arguments3 as  Map<String, dynamic>:{};
```

```dart
    data = data.isNotEmpty ? data = data :
      data = ModalRoute.of(context)!.settings.arguments as Map;
```